### PR TITLE
Use Crypt::SysRandom to generate nonces instead of Data::UUID

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -22,6 +22,7 @@ StaticInstall.dry_run = 0   ; we can safely set this here
 
 [Prereqs]
 Catalyst::Plugin::Authentication = 0.10005
+Crypt::SysRandom = 0
 
 [Prereqs / DevelopRequires]
 Test::WWW::Mechanize::Catalyst = 0.51

--- a/lib/Catalyst/Authentication/Credential/HTTP.pm
+++ b/lib/Catalyst/Authentication/Credential/HTTP.pm
@@ -380,7 +380,9 @@ package # hide from PAUSE
 
 use strict;
 use base qw[ Class::Accessor::Fast ];
-use Data::UUID 0.11 ();
+use Crypt::SysRandom;
+
+# RECOMMEND PRERQ: Crypt::SysRandom::XS 0.009
 
 __PACKAGE__->mk_accessors(qw[ nonce nonce_count qop opaque algorithm ]);
 
@@ -388,14 +390,19 @@ sub new {
     my $class = shift;
     my $self  = $class->SUPER::new(@_);
 
-    $self->nonce( Data::UUID->new->create_b64 );
-    $self->opaque( Data::UUID->new->create_b64 );
+    $self->nonce( $self->_generate_nonce );
+    $self->opaque( $self->_generate_nonce );
     $self->qop('auth,auth-int');
     $self->nonce_count('0x0');
     $self->algorithm('MD5');
 
     return $self;
 }
+
+sub _generate_nonce {
+    return unpack('H*', Crypt::SysRandom::random_bytes(20));
+}
+
 
 1;
 


### PR DESCRIPTION
The nonce should be generated from a strong cryptographic source as per RFC 7616.

Data::UUID generates v3 UUIDs, which are generated from known information and are unsuitable for security, as per RFC 9562.

Data::UUID does not use a strong cryptographic source for generating UUIDs.